### PR TITLE
Improve keyboard control in menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ CC = g++
 CCFLAGS = -w -fpermissive
 LDFLAGS = `allegro-config --libs`
 FILES = boatrage.cc control.cc mapedit.cc menu.cc menumagm.cc objects.cc player.cc sprite.cc tilemap.cc view.cc wrappers.cc
+HEADERS = boatrage.h control.h data.h mapedit.h menu.h menumagm.h objects.h player.h sprite.h strings.h tilemap.h view.h wrappers.h
 
-boatrage: $(FILES)
+boatrage: $(FILES) $(HEADERS)
 	$(CC) $(CCFLAGS) -o boatrage $(FILES) $(LDFLAGS)
 
 clean:

--- a/menu.cc
+++ b/menu.cc
@@ -4,6 +4,7 @@
 
 int coolmenu(RLE_SPRITE *background, coolmenuitem *items, int count, int sel) {
  int i,first=1;
+ int changed=0;
  clear(display);
  display.goblack();
  text_mode(-1);
@@ -17,16 +18,24 @@ int coolmenu(RLE_SPRITE *background, coolmenuitem *items, int count, int sel) {
   draw_trans_rle_sprite(display,(RLE_SPRITE *)d(SELECTOR),items[sel].x+SCR_X,items[sel].y+SCR_Y);
   display.flip();
   if (first) {first=0; display.fadein(4);}
+
+  if (changed && (key[KEY_DOWN] || key[KEY_UP]))
+   continue;
+  else
+   changed=0;
+
   if (key[KEY_UP])    {
    clear_keybuf();
    Sound.play((SAMPLE *)d(SND_CHOOSE));
    sel--;
    clear(display);
+   changed=1;
   }
   if (key[KEY_DOWN])  {
    clear_keybuf();
    Sound.play((SAMPLE *)d(SND_CHOOSE));
    sel++;
+   changed=1;
   }
   if (key[KEY_ENTER]) {
    clear_keybuf();

--- a/menumagm.cc
+++ b/menumagm.cc
@@ -479,8 +479,6 @@ int selectlevel(int std, int still) {
   clear(display);
   draw_rle_sprite(display,(RLE_SPRITE *)d(CLOUDS),SCR_X,SCR_Y);
   if (changed) {
-   Sound.play((SAMPLE *)d(SND_CHOOSE));
-   changed=0;
    sprintf(file,"l%i.boa",l);
    if (exists(file)) {
     map->closemap();
@@ -514,10 +512,17 @@ int selectlevel(int std, int still) {
   vsync();
   blit(display,screen,0,0,0,0,SCREEN_W,SCREEN_H);
   if (first) {first=0; display.fadein(3);}
+
+  if (changed && (key[KEY_DOWN] || key[KEY_UP]))
+   continue;
+  else
+   changed=0;
+
   if (still==0) {
    if (key[KEY_DOWN])   {clear_keybuf();l++;changed=1;}
    if (key[KEY_UP] && l>1) {clear_keybuf();l--;changed=1;}
   }
+  if (changed) Sound.play((SAMPLE *)d(SND_CHOOSE));
   if (key[KEY_ENTER]) {
    Sound.play((SAMPLE *)d(SND_SELECT));
    clear_keybuf();


### PR DESCRIPTION
The keyboard control in the menu is much too fast. When up or down are pressed the selection quickly jumps over multiple menu items. With this PR keeping up or down pressed the selection is only moved to the neighboring menu item.